### PR TITLE
Adjust log location for macOS

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,9 +2,9 @@
 <configuration>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.home}/.shogun/shogun.log</file>
+        <file>${user.home}/Library/Logs/Shogun/shogun.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${user.home}/.shogun/shogun_%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${user.home}/Library/Logs/Shogun/shogun_%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>10</maxHistory>
         </rollingPolicy>
 


### PR DESCRIPTION
On macOS, the log about application is generally output to `$HOME/Library/Logs/` or `/var/log/`.
I would say`$HOME/Library/Logs/` location is better in this case.