### PR TITLE
Support JDK Scan for user local library directory

### DIFF
--- a/src/main/java/shogun/sdk/JDKScanner.java
+++ b/src/main/java/shogun/sdk/JDKScanner.java
@@ -15,6 +15,7 @@ public class JDKScanner {
         Platform.isMac(() -> {
             result.addAll(searchJDKs(new File("/Library/Java/JavaVirtualMachines")));
             result.addAll(searchJDKs(new File(System.getProperty("user.home"))));
+            result.addAll(searchJDKs(new File(System.getProperty("user.home") + File.separator + "Library/Java/JavaVirtualMachines")));
             result.addAll(searchJDKs(new File(System.getProperty("user.home") + File.separator + "Downloads")));
         });
         List<NotRegisteredVersion> versionList = new ArrayList<>();


### PR DESCRIPTION
Installing a JDK using pkg of Oracle, for example, the user may run a script like

```sh
installer -pkg jdk.pkg -target CurrentUserHomeDirectory
```

Then, the JDK is installed to `$HOME/Library/Java/JavaVirtualMachines`.

This method is often used because it does not globally contaminate the device.
I would say it should take precedence over user home directory and Downloads directory.