### PR TITLE
Redirect stderr to stdout on detection sdkman dir

### DIFF
--- a/src/main/java/shogun/sdk/SDK.java
+++ b/src/main/java/shogun/sdk/SDK.java
@@ -310,7 +310,7 @@ public class SDK {
 
     static String getSDK_MAN_DIR() {
         if (sdkManDir == null) {
-            sdkManDir = SDKLauncher.exec("source ~/.bash_profile>/dev/null;echo $SDKMAN_DIR").trim();
+            sdkManDir = SDKLauncher.exec("source ~/.bash_profile>/dev/null 2>&1;echo $SDKMAN_DIR").trim();
             var matcher = Pattern.compile("^/([a-zA-Z])(/.*)$").matcher(sdkManDir);
             if (matcher.matches()) {
                 sdkManDir = matcher.replaceFirst("$1:$2");


### PR DESCRIPTION
In my environment, I don't have .bash_profile(I use zsh) and then no such file error is printed before $SDKMAN_DIR:
```
2019-08-21 15:26:55,669 [main] INFO  shogun.sdk.SDK - SHOGUN_VERSION: 1.0.11
2019-08-21 15:26:56,265 [main] DEBUG shogun.task.TaskTray - Loading Duke images.
2019-08-21 15:26:56,278 [AWT-EventQueue-0] DEBUG shogun.task.TaskTray - Preparing task tray.
2019-08-21 15:26:56,305 [Shogun Execute Thread[0]] DEBUG shogun.task.TaskTray - Initializing menu items.
2019-08-21 15:26:56,353 [Shogun Execute Thread[0]] DEBUG shogun.sdk.SDKLauncher - Command to be executed: [source ~/.bash_profile>/dev/null;echo $SDKMAN_DIR]
2019-08-21 15:26:56,403 [Shogun Execute Thread[0]] DEBUG shogun.sdk.SDKLauncher - Response:
2019-08-21 15:26:56,403 [Shogun Execute Thread[0]] DEBUG shogun.sdk.SDKLauncher - bash: /home/bitterfox/.bash_profile: No such file or directory
/home/bitterfox/.sdkman

2019-08-21 15:26:56,404 [Shogun Execute Thread[0]] DEBUG shogun.sdk.SDK - SDKMAN_DIR: bash: /home/bitterfox/.bash_profile: No such file or directory
/home/bitterfox/.sdkman
2019-08-21 15:26:56,408 [Shogun Execute Thread[0]] DEBUG shogun.task.TaskTray - Offline mode.
2019-08-21 15:26:56,410 [Shogun Execute Thread[0]] DEBUG shogun.sdk.SDKLauncher - Command to be executed: [source bash: /home/bitterfox/.bash_profile: No such file or directory
/home/bitterfox/.sdkman/bin/sdkman-init.sh;sdk list]
2019-08-21 15:26:56,489 [Shogun Execute Thread[0]] DEBUG shogun.sdk.SDKLauncher - Response:
2019-08-21 15:26:56,489 [Shogun Execute Thread[0]] DEBUG shogun.sdk.SDKLauncher - bash: bash:: No such file or directory
bash: line 1: sdk: command not found
```

Let's redirect stderr to /dev/null too.