### PR TITLE
Support Open in Finder for Linux env

### DIFF
--- a/src/main/java/shogun/sdk/Platform.java
+++ b/src/main/java/shogun/sdk/Platform.java
@@ -57,7 +57,7 @@ public final class Platform {
         }
     }
 
-    static void isLinux(Runnable runnable) {
+    public static void isLinux(Runnable runnable) {
         if (platform == OS.LINUX) {
             try {
                 runnable.run();

--- a/src/main/java/shogun/task/TaskTray.java
+++ b/src/main/java/shogun/task/TaskTray.java
@@ -553,6 +553,13 @@ public class TaskTray {
                 logger.error("Failed to open command prompt.", e);
             }
         });
+        Platform.isLinux(() -> {
+            try {
+                Runtime.getRuntime().exec(new String[]{"xdg-open", path});
+            } catch (IOException e) {
+                logger.error("Failed to open {}", path, e);
+            }
+        });
     }
 
     private static String toLabel(Version version) {


### PR DESCRIPTION
https://wiki.archlinux.org/index.php/Xdg-utils#xdg-open

`xdg-open is desktop-environment-independent in the sense that it attempts to use each environment's native default application tool.`
So, this command will work well across most of the desktop environment of Linux.

