### PR TITLE
refactor remove File.separator

### DIFF
--- a/src/main/java/shogun/sdk/JDKScanner.java
+++ b/src/main/java/shogun/sdk/JDKScanner.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -76,11 +77,11 @@ public class JDKScanner {
             if (files != null) {
                 for (File candidate : files) {
                     if (!Files.isSymbolicLink(candidate.toPath())) {
-                        File javaHome = new File(candidate.getAbsolutePath() + File.separator + "Contents" + File.separator + "Home");
+                        File javaHome = Paths.get(candidate.getAbsolutePath(), "Contents", "Home").toFile();
                         if (javaHome.exists() && javaHome.isDirectory()) {
                             result.add(javaHome);
                         } else if (candidate.exists() && candidate.isDirectory()) {
-                            File javaCommand = new File(candidate.getAbsolutePath() + File.separator + "bin" + File.separator + "java");
+                            File javaCommand = Paths.get(candidate.getAbsolutePath(), "bin", "java").toFile();
                             if (javaCommand.exists() && javaCommand.isFile()) {
                                 result.add(javaHome);
                             }

--- a/src/main/java/shogun/sdk/SDK.java
+++ b/src/main/java/shogun/sdk/SDK.java
@@ -32,7 +32,7 @@ public class SDK {
     }
 
     public boolean isInstalled() {
-        return Files.exists(Paths.get(getSDK_MAN_DIR() + File.separator + "bin" + File.separator + "sdkman-init.sh"));
+        return Files.exists(Paths.get(getSDK_MAN_DIR(), "bin", "sdkman-init.sh"));
     }
 
     public String install() {
@@ -55,7 +55,7 @@ public class SDK {
 
     @NotNull
     private File getArchiveDir() {
-        return new File(SDK.getSDK_MAN_DIR() + File.separator + "archives");
+        return Paths.get(SDK.getSDK_MAN_DIR(), "archives").toFile();
     }
 
     boolean isArchiveExists() {
@@ -280,7 +280,7 @@ public class SDK {
             throw new IllegalStateException("SDKMAN! not installed!");
         }
         var candidates = new ArrayList<String>();
-        File[] candidateDirs = new File(getSDK_MAN_DIR() + File.separator + "candidates").listFiles();
+        File[] candidateDirs = Paths.get(getSDK_MAN_DIR(), "candidates").toFile().listFiles();
         if (candidateDirs != null) {
             for (File file : candidateDirs) {
                 if (file.isDirectory()) {
@@ -307,7 +307,7 @@ public class SDK {
     }
 
     static List<String> listLocallyInstalledPaths() {
-        File file = new File(SDK.getSDK_MAN_DIR() + File.separator + "candidates" + File.separator + "java");
+        File file = Paths.get(SDK.getSDK_MAN_DIR(), "candidates", "java").toFile();
         List<String> list = new ArrayList<>();
         if (file.exists() && file.isDirectory()) {
             File[] files = file.listFiles();

--- a/src/main/java/shogun/sdk/Version.java
+++ b/src/main/java/shogun/sdk/Version.java
@@ -90,17 +90,17 @@ public class Version {
 
     @NotNull
     private File getArchiveFile() {
-        return new File(SDK.getSDK_MAN_DIR() + File.separator + "archives" + File.separator + candidate + "-" + getIdentifier() + ".zip");
+        return Paths.get(SDK.getSDK_MAN_DIR(), "archives", candidate + "-" + getIdentifier() + ".zip").toFile();
     }
 
     @NotNull
     private Path getInstallationDir() {
-        return Paths.get(SDK.getSDK_MAN_DIR() + File.separator + "candidates" + File.separator + candidate + File.separator + getIdentifier());
+        return Paths.get(SDK.getSDK_MAN_DIR(), "candidates", candidate, getIdentifier());
     }
 
     @NotNull
     private Path getCurrentDir() {
-        return Paths.get(SDK.getSDK_MAN_DIR() + File.separator + "candidates" + File.separator + candidate + File.separator + "current");
+        return Paths.get(SDK.getSDK_MAN_DIR(), "candidates", candidate, "current");
     }
 
     @SuppressWarnings("unused")
@@ -136,7 +136,7 @@ public class Version {
     }
 
     public String getPath() {
-        return new File(SDK.getSDK_MAN_DIR() + File.separator + "candidates" + File.separator + candidate + File.separator + getIdentifier()).getAbsolutePath();
+        return Paths.get(SDK.getSDK_MAN_DIR(), "candidates", candidate, getIdentifier()).toFile().getAbsolutePath();
     }
 
     public String getIdentifier() {

--- a/src/test/java/shogun/jpackage/JPackagerDownloader.java
+++ b/src/test/java/shogun/jpackage/JPackagerDownloader.java
@@ -53,15 +53,15 @@ class JPackagerDownloader {
                     conn.disconnect();
                 }
             }
-            unZip(packagerRoot, Paths.get("jdk.packager" + File.separator + fileName));
+            unZip(packagerRoot, Paths.get("jdk.packager", fileName));
             Path bin = packagerRoot.resolve("jpackager" + (isWindows ? ".exe" : ""));
             //noinspection ResultOfMethodCallIgnored
             bin.toFile().setExecutable(true);
             if (isWindows) {
                 // jpackager.exe needs to be located in %JAVA_HOME%\bin
-                Files.move(bin, Path.of(System.getProperty("java.home") + File.separator + "bin" + File.separator + "jpackager.exe"));
+                Files.move(bin, Path.of(System.getProperty("java.home"), "bin", "jpackager.exe"));
                 // jdk.packager.jar needs to be located in %JAVA_HOME%\bin
-                Files.move(packagerRoot.resolve("jdk.packager.jar"), Path.of(System.getProperty("java.home") + File.separator + "bin" + File.separator + "jdk.packager.jar"));
+                Files.move(packagerRoot.resolve("jdk.packager.jar"), Path.of(System.getProperty("java.home"), "bin", "jdk.packager.jar"));
             }
         }
     }

--- a/src/test/java/shogun/sdk/JDKScannerTest.java
+++ b/src/test/java/shogun/sdk/JDKScannerTest.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import shogun.logging.LoggerFactory;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -90,7 +91,7 @@ class JDKScannerTest {
     }
 
     private void deleteSymbolicLinks(String[] versions) throws IOException {
-        File[] registeredJavaVersions = new File(SDK.getSDK_MAN_DIR() + File.separator + "candidates" + File.separator + "java").listFiles();
+        File[] registeredJavaVersions = Paths.get(SDK.getSDK_MAN_DIR(), "candidates", "java").toFile().listFiles();
         // remove previously registered dummy versions
         if (registeredJavaVersions != null) {
             for (File registeredJavaVersion : registeredJavaVersions) {

--- a/src/test/java/shogun/sdk/SDKTest.java
+++ b/src/test/java/shogun/sdk/SDKTest.java
@@ -29,7 +29,7 @@ class SDKTest {
 
         SDK sdk = new SDK();
         if (sdk.isInstalled()) {
-            assertEquals(new File(System.getProperty("user.home") + File.separator + ".sdkman").compareTo(new File(SDK.getSDK_MAN_DIR())), 0);
+            assertEquals(Paths.get(System.getProperty("user.home"),".sdkman").toFile().compareTo(new File(SDK.getSDK_MAN_DIR())), 0);
         }
     }
 
@@ -354,7 +354,7 @@ class SDKTest {
         assumeTrue(sdk.isInstalled());
 
         // version is stored in ~/.sdkman/var/version
-        List<String> lines = Files.readAllLines(Paths.get(SDK.getSDK_MAN_DIR() + File.separator + "var" + File.separator + "version"));
+        List<String> lines = Files.readAllLines(Paths.get(SDK.getSDK_MAN_DIR(), "var", "version"));
         // X.Y.Z+nnn
         String versionFullString = lines.get(0);
 


### PR DESCRIPTION
File.separatorをできるだけ削除しました。

File.separatorが残っている箇所は、Paths.get()のNotNull制約に引っかかってしまうため、そのままにしている箇所もあります。
また、単純なStringを期待している箇所についても、そのままにしています。